### PR TITLE
Fixes "T" keyup glitch

### DIFF
--- a/fmc_v0.4.0.user.js
+++ b/fmc_v0.4.0.user.js
@@ -1460,3 +1460,9 @@ Array.prototype.move = function (index1, index2) {
     return this;
 };
 
+// Fixes the "T" keyup bug
+var oldOpen = ui.openChat;
+
+ui.openChat = function () {
+	if (!$('#fmcModal').is(':visible')) oldOpen();
+}

--- a/fmc_v0.4.0.user.js
+++ b/fmc_v0.4.0.user.js
@@ -1461,8 +1461,13 @@ Array.prototype.move = function (index1, index2) {
 };
 
 // Fixes the "T" keyup bug
+/*
 var oldOpen = ui.openChat;
 
 ui.openChat = function () {
 	if (!$('#fmcModal').is(':visible')) oldOpen();
 }
+*/
+$('#fmcModal').keyup(function (event) {
+  event.stopImmediatePropagation();
+});


### PR DESCRIPTION
### This is a very stupid fix, but it works. Basically nobody can access chat if the FMC dialog window is open.
